### PR TITLE
:sparkles: Add read access to the document index 

### DIFF
--- a/src/main/java/com/penguineering/mnrmapi/index/DocumentIndex.java
+++ b/src/main/java/com/penguineering/mnrmapi/index/DocumentIndex.java
@@ -1,0 +1,124 @@
+package com.penguineering.mnrmapi.index;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An index representing a document on the re:markable tablet.
+ */
+public class DocumentIndex {
+    public static Builder buildFromIndexEntry(IndexEntry docRoot) {
+        return new Builder(docRoot.getGcsPath(), docRoot.getId());
+    }
+
+    public static class Builder {
+        private final String indexGCS;
+
+        private final String docId;
+
+        private String contentGCS = null;
+        private String metadataGCS = null;
+
+        private final Map<String, String> additionalGCS = new HashMap<>();
+
+        Builder(String indexGCS, String docId) {
+            this.indexGCS = indexGCS;
+            this.docId = docId;
+        }
+
+        public Builder parseIndexEntry(IndexEntry entry) {
+            final String id = entry.getId();
+
+            // split doc id
+            if (!id.startsWith(this.docId))
+                throw new IllegalArgumentException("Document ID mismatch!");
+
+            final String suffix = id.substring(this.docId.length());
+            if (suffix.equals(".content"))
+                return this.setContentGCS(entry.getGcsPath());
+
+            if (suffix.equals(".metadata"))
+                return this.setMetadataGCS(entry.getGcsPath());
+
+            return this.addAdditionalGCS(suffix, entry.getGcsPath());
+        }
+
+        public Builder setContentGCS(String contentGCS) {
+            this.contentGCS = contentGCS;
+            return this;
+        }
+
+        public Builder setMetadataGCS(String metadataGCS) {
+            this.metadataGCS = metadataGCS;
+            return this;
+        }
+
+        public Builder addAdditionalGCS(String key, String gcs) {
+            this.additionalGCS.put(key, gcs);
+            return this;
+        }
+
+        public DocumentIndex build() {
+            return new DocumentIndex(
+                    indexGCS,
+                    docId,
+                    contentGCS,
+                    metadataGCS,
+                    Collections.unmodifiableMap(additionalGCS));
+        }
+    }
+
+    private final String indexGCS;
+    private final String docId;
+    private final String contentGCS;
+    private final String metadataGCS;
+    private final Map<String, String> additionalGCS;
+
+    public DocumentIndex(String indexGCS,
+                         String docId,
+                         String contentGCS,
+                         String metadataGCS,
+                         Map<String, String> additionalGCS) {
+        this.indexGCS = indexGCS;
+        this.docId = docId;
+        this.contentGCS = contentGCS;
+        this.metadataGCS = metadataGCS;
+        this.additionalGCS = additionalGCS;
+    }
+
+    public String getIndexGCS() {
+        return indexGCS;
+    }
+
+    public String getDocId() {
+        return docId;
+    }
+
+    public String getContentGCS() {
+        return contentGCS;
+    }
+
+    public String getMetadataGCS() {
+        return metadataGCS;
+    }
+
+    public Map<String, String> getAdditionalGCS() {
+        return additionalGCS;
+    }
+
+    public int length() {
+        return (contentGCS == null ? 0 : 1)
+                + (metadataGCS == null ? 0 : 1)
+                + (additionalGCS == null ? 0 : additionalGCS.size());
+    }
+
+    @Override
+    public String toString() {
+        return "DocumentIndex{" +
+                "docId='" + docId + '\'' +
+                ", indexGCS='" + indexGCS + '\'' +
+                ", length=" + length() +
+                '}';
+    }
+}

--- a/src/main/java/com/penguineering/mnrmapi/index/IndexAccess.java
+++ b/src/main/java/com/penguineering/mnrmapi/index/IndexAccess.java
@@ -1,0 +1,44 @@
+package com.penguineering.mnrmapi.index;
+
+import com.penguineering.mnrmapi.gcs.GcsAccess;
+import io.micronaut.context.annotation.Bean;
+import jakarta.inject.Inject;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Bean
+public class IndexAccess {
+    @Inject
+    protected GcsAccess gcsAccess;
+
+    public Flux<IndexEntry> retrieveIndex(Flux<String> gcsPath) {
+        return gcsPath
+                .transform(gcsAccess::retrieve)
+                .map(IndexEntry::fromData)
+                .flatMap(Flux::fromIterable);
+    }
+
+    public Flux<String> retrieveRootGcs() {
+        return Flux
+                .just("root")
+                .transform(gcsAccess::retrieve);
+    }
+
+    public Flux<IndexEntry> retrieveRootIndex() {
+        return retrieveRootGcs()
+                .transform(this::retrieveIndex);
+    }
+
+    public Flux<DocumentIndex> retrieveDocumentIndex(Flux<IndexEntry> entries) {
+        return entries
+                .flatMap(e ->
+                        Mono.just(DocumentIndex.buildFromIndexEntry(e))
+                                .repeat()
+                                .zipWith(
+                                        Flux.just(e.getGcsPath())
+                                                .transform(this::retrieveIndex))
+                                .map(t -> t.getT1().parseIndexEntry(t.getT2()))
+                                .last()
+                                .map(DocumentIndex.Builder::build));
+    }
+}

--- a/src/main/java/com/penguineering/mnrmapi/index/IndexEntry.java
+++ b/src/main/java/com/penguineering/mnrmapi/index/IndexEntry.java
@@ -1,0 +1,67 @@
+package com.penguineering.mnrmapi.index;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class IndexEntry {
+    private static final Pattern LINE_ENDINGS = Pattern.compile("\n");
+
+    public static IndexEntry fromLine(String line) {
+        String[] parts = line.split(":");
+        if (parts.length < 5)
+            throw new IllegalArgumentException("Line cannot be split into 5 parts: " + line);
+
+        final String gcsPath = parts[0];
+        final String id = parts[2];
+        final Integer entriesCount = Integer.parseInt(parts[3]);
+        final Long size = Long.parseLong(parts[4]);
+
+        return new IndexEntry(gcsPath, id, entriesCount, size);
+    }
+
+    public static List<IndexEntry> fromData(String data) {
+        return LINE_ENDINGS
+                .splitAsStream(data)
+                .skip(1)
+                .map(IndexEntry::fromLine)
+                .toList();
+    }
+
+    private final String gcsPath;
+    private final String id;
+    private final Integer entriesCount;
+    private final Long size;
+
+    IndexEntry(String gcsPath, String id, Integer entriesCount, Long size) {
+        this.gcsPath = gcsPath;
+        this.id = id;
+        this.entriesCount = entriesCount;
+        this.size = size;
+    }
+
+    public String getGcsPath() {
+        return gcsPath;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public Integer getEntriesCount() {
+        return entriesCount;
+    }
+
+    public Long getSize() {
+        return size;
+    }
+
+    @Override
+    public String toString() {
+        return "IndexEntry{" +
+                "gcsPath='" + gcsPath + '\'' +
+                ", id='" + id + '\'' +
+                ", entriesCount=" + entriesCount +
+                ", size=" + size +
+                '}';
+    }
+}


### PR DESCRIPTION
Allows to read the root index (all documents/folders on the device) and the document indexes (each Document is an  index with several files).